### PR TITLE
fix `autoEnd` not working when `total` is false

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,15 +23,16 @@ module.exports = function serverTiming (options) {
     res.endTime = endTime(timer, res)
 
     onHeaders(res, () => {
+      if (opts.autoEnd) {
+        const keys = timer.keys()
+        for (const key of keys) {
+          res.endTime(key)
+        }
+      }
+
       if (opts.total) {
         const diff = process.hrtime(startAt)
         const timeSec = (diff[0] * 1E3) + (diff[1] * 1e-6)
-        if (opts.autoEnd) {
-          const keys = timer.keys()
-          for (const key of keys) {
-            res.endTime(key)
-          }
-        }
         headers.push(`total; dur=${timeSec}; desc="Total Response Time"`)
       }
       timer.clear()

--- a/test/express-test.js
+++ b/test/express-test.js
@@ -90,3 +90,21 @@ test('express stop automatic timer', () => {
     }))
   })
 })
+
+test('express stop automatic timer (without total)', () => {
+  const app = express()
+  app.use(serverTiming({total: false}))
+  app.use((req, res, next) => {
+    res.startTime('hello', 'hello')
+    res.send('hello')
+  })
+  const server = app.listen(0, () => {
+    http.get(`http://localhost:${server.address().port}/`, mustCall((res) => {
+      const assertStream = new AssertStream()
+      assertStream.expect('hello')
+      res.pipe(assertStream)
+      assert(/hello; dur=.*; desc="hello"$/.test(res.headers['server-timing']))
+      server.close()
+    }))
+  })
+})

--- a/test/http-basic-test.js
+++ b/test/http-basic-test.js
@@ -127,7 +127,26 @@ test('success: stop automatically timer', () => {
       assertStream.expect('hello')
       res.pipe(assertStream)
       assert(res.headers['server-timing'])
-      console.log(res.headers)
+      assert(res.headers['server-timing'].includes('foo; dur='))
+      assert(res.headers['server-timing'].includes('total; dur='))
+      server.close()
+    }))
+  })
+})
+
+test('success: stop automatically timer (without total)', () => {
+  const server = http.createServer((req, res) => {
+    serverTiming({total: false})(req, res)
+    res.startTime('foo', 'foo')
+    res.end('hello')
+  }).listen(0, () => {
+    http.get(`http://localhost:${server.address().port}/`, mustCall((res) => {
+      const assertStream = new AssertStream()
+      assertStream.expect('hello')
+      res.pipe(assertStream)
+      assert(res.headers['server-timing'])
+      assert(res.headers['server-timing'].includes('foo; dur='))
+      assert(!res.headers['server-timing'].includes('total; dur='))
       server.close()
     }))
   })


### PR DESCRIPTION
Currently, `autoEnd` does not work if `total` is set to true, because the `autoEnd` check is run inside of the  `total` check. This PR fixes that, and adds tests to prevent regressions.