### PR TITLE
allow specifying metric precision (fixes #43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ app.use((req, res, next) => {
 
 - options.total: boolean, default `true`, add total response time
 - options.enabled: boolean, default `true`, enable server timing header 
-- options.autoEnd: boolean, default `true` automatically endTime is called if timer is not finished.
+- options.autoEnd: boolean, default `true`, automatically endTime is called if timer is not finished.
+- options.precision: number, default `+Infinity`, number of decimals to use for timings.
 
 # Result
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ declare module "server-timing" {
     total?: boolean;
     enabled?: boolean;
     autoEnd?: boolean;
+    precision?: number;
   };
   const _default: (opts?: Options) => e.RequestHandler;
   export default _default;

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ module.exports = function serverTiming (options) {
   const opts = Object.assign({
     total: true,
     enabled: true,
-    autoEnd: true
+    autoEnd: true,
+    precision: +Infinity
   }, options)
   return (_, res, next) => {
     const headers = []
@@ -18,7 +19,7 @@ module.exports = function serverTiming (options) {
 
     const startAt = process.hrtime()
 
-    res.setMetric = setMetric(headers)
+    res.setMetric = setMetric(headers, opts)
     res.startTime = startTime(timer)
     res.endTime = endTime(timer, res)
 
@@ -33,7 +34,7 @@ module.exports = function serverTiming (options) {
       if (opts.total) {
         const diff = process.hrtime(startAt)
         const timeSec = (diff[0] * 1E3) + (diff[1] * 1e-6)
-        headers.push(`total; dur=${timeSec}; desc="Total Response Time"`)
+        res.setMetric('total', timeSec, 'Total Response Time')
       }
       timer.clear()
 
@@ -49,7 +50,7 @@ module.exports = function serverTiming (options) {
   }
 }
 
-function setMetric (headers) {
+function setMetric (headers, opts) {
   return (name, value, description) => {
     if (typeof name !== 'string') {
       return console.warn('1st argument name is not string')
@@ -58,8 +59,11 @@ function setMetric (headers) {
       return console.warn('2nd argument value is not number')
     }
 
+    const dur = Number.isFinite(opts.precision)
+      ? value.toFixed(opts.precision) : value
+
     const metric = typeof description !== 'string' || !description
-      ? `${name}; dur=${value}` : `${name}; dur=${value}; desc="${description}"`
+      ? `${name}; dur=${dur}` : `${name}; dur=${dur}; desc="${description}"`
 
     headers.push(metric)
   }

--- a/test/express-test.js
+++ b/test/express-test.js
@@ -108,3 +108,28 @@ test('express stop automatic timer (without total)', () => {
     }))
   })
 })
+
+test('express specify precision', () => {
+  const app = express()
+  app.use(serverTiming({precision: 2}))
+  app.use((req, res, next) => {
+    res.setMetric('manual', 100 / 3)
+    res.startTime('auto')
+    process.nextTick(() => {
+      res.endTime('auto')
+      res.send('hello')
+    })
+  })
+  const server = app.listen(0, () => {
+    http.get(`http://localhost:${server.address().port}/`, mustCall((res) => {
+      const assertStream = new AssertStream()
+      assertStream.expect('hello')
+      res.pipe(assertStream)
+      const timingHeader = res.headers['server-timing']
+      assert(/total; dur=\d+\.\d{2}[;,]/.test(timingHeader))
+      assert(/manual; dur=\d+\.\d{2}[;,]/.test(timingHeader))
+      assert(/auto; dur=\d+\.\d{2}[;,]/.test(timingHeader))
+      server.close()
+    }))
+  })
+})

--- a/test/http-basic-test.js
+++ b/test/http-basic-test.js
@@ -151,3 +151,27 @@ test('success: stop automatically timer (without total)', () => {
     }))
   })
 })
+
+test('success: specify precision', () => {
+  const server = http.createServer((req, res) => {
+    serverTiming({precision: 3})(req, res)
+    res.setMetric('manual', 100 / 3)
+    res.startTime('auto')
+    process.nextTick(() => {
+      res.endTime('auto')
+      res.end('hello')
+    })
+  }).listen(0, () => {
+    http.get(`http://localhost:${server.address().port}/`, mustCall((res) => {
+      const assertStream = new AssertStream()
+      assertStream.expect('hello')
+      res.pipe(assertStream)
+      const timingHeader = res.headers['server-timing']
+      assert(timingHeader)
+      assert(/total; dur=\d+\.\d{3}[;,]/.test(timingHeader))
+      assert(/manual; dur=\d+\.\d{3}[;,]/.test(timingHeader))
+      assert(/auto; dur=\d+\.\d{3}[;,]/.test(timingHeader))
+      server.close()
+    }))
+  })
+})


### PR DESCRIPTION
In certain cases, sub-millisecond precision isn't important. This PR allows the user to specify a `precision` number, saying how many decimals to use.

To avoid having to do the precision check multiple places, I made the "total" timer reuse the `setMetric` function. I hope that's OK.