### PR TITLE
allow conditionally enabling timings

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,25 @@ app.use((req, res, next) => {
 });
 ```
 
+## Conditionally enabled
+
+```javascript
+const express = require('express');
+const serverTiming = require('server-timing');
+
+const app = express();
+app.use(serverTiming({
+  // Only send metrics if query parameter `debug` is set to `true`
+  enabled: (req, res) => req.query.debug === 'true'
+}));
+```
+
 # API
 
 ## constructor(options)
 
 - options.total: boolean, default `true`, add total response time
-- options.enabled: boolean, default `true`, enable server timing header 
+- options.enabled: boolean | function, default `true`, enable server timing header. If a function is passed, it will be called with two arguments, `request` and `response`, and should return a boolean.
 - options.autoEnd: boolean, default `true` automatically endTime is called if timer is not finished.
 
 # Result

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ declare module "server-timing" {
   import * as e from "express";
   type Options = {
     total?: boolean;
-    enabled?: boolean;
+    enabled?: boolean | IsEnabledCheck;
     autoEnd?: boolean;
   };
   const _default: (opts?: Options) => e.RequestHandler;
@@ -11,5 +11,6 @@ declare module "server-timing" {
     startTime: (name: string, desc: string) => void;
     endTime: (name: string) => void;
   };
+  export type IsEnabledCheck = (req: e.Request, res: e.Response) => boolean
   export type SeverTimingResponse = e.Response & Response;
 }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function serverTiming (options) {
     enabled: true,
     autoEnd: true
   }, options)
-  return (_, res, next) => {
+  return (req, res, next) => {
     const headers = []
     const timer = new Timer()
     if (res.setMetric) {
@@ -36,7 +36,10 @@ module.exports = function serverTiming (options) {
       }
       timer.clear()
 
-      if (opts.enabled) {
+      const enabled = typeof opts.enabled === 'function'
+        ? opts.enabled(req, res) : opts.enabled
+
+      if (enabled) {
         const existingHeaders = res.getHeader('Server-Timing')
 
         res.setHeader('Server-Timing', [].concat(existingHeaders || []).concat(headers).join(', '))


### PR DESCRIPTION
Sometimes you only want to expose the metrics if a certain condition holds true. Obvious candidate is for debugging, in which case you may want to expose them only if:

- Remote IP matches a certain value/range
- A secret debug query parameter is present
- A certain header is present
- The current user session has certain properties

This PR allows the `enabled` option to take a function that can determine whether or not to include the metrics on a per-request basis. All of the above (and more) should be possible by peaking into the `request` object (and in certain cases, the `response`).

