### PR TITLE
extends Express global response interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,10 +8,18 @@ declare module "server-timing" {
   };
   const _default: (opts?: Options) => e.RequestHandler;
   export default _default;
-  type Response = {
+  type _Response = {
     startTime: (name: string, desc: string) => void;
     endTime: (name: string) => void;
+    setMetric: (name: string, value: number, description?: string) => void;
   };
   export type IsEnabledCheck = (req: e.Request, res: e.Response) => boolean
-  export type SeverTimingResponse = e.Response & Response;
+  export type SeverTimingResponse = e.Response & _Response;
+
+  global {
+    namespace Express {
+      interface Response extends _Response {
+      }
+    }
+  }
 }


### PR DESCRIPTION
Hi. I found the following index.d.ts errors.

<img width="902" alt="スクリーンショット 2020-03-24 17 04 44" src="https://user-images.githubusercontent.com/1262998/77402184-9dc99080-6df1-11ea-8c92-ab93a98cdf30.png">

I think it's better to merge `Express.Response` declarations.
( https://www.typescriptlang.org/docs/handbook/declaration-merging.html#merging-interfaces )