### PR TITLE
Allow for custom name and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ app.use(serverTiming({
 
 ## constructor(options)
 
+- options.name: string, default `total`, name for the timing item
+- options.description: string, default `Total Response Time`, explanation for the timing item
 - options.total: boolean, default `true`, add total response time
 - options.enabled: boolean | function, default `true`, enable server timing header. If a function is passed, it will be called with two arguments, `request` and `response`, and should return a boolean.
 - options.autoEnd: boolean, default `true` automatically endTime is called if timer is not finished.

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const Timer = require('./timer')
 
 module.exports = function serverTiming (options) {
   const opts = Object.assign({
+    name: 'total',
+    description: 'Total Response Time',
     total: true,
     enabled: true,
     autoEnd: true,
@@ -34,7 +36,7 @@ module.exports = function serverTiming (options) {
       if (opts.total) {
         const diff = process.hrtime(startAt)
         const timeSec = (diff[0] * 1E3) + (diff[1] * 1e-6)
-        res.setMetric('total', timeSec, 'Total Response Time')
+        res.setMetric(opts.name, timeSec, opts.description)
       }
       timer.clear()
 

--- a/test/express-test.js
+++ b/test/express-test.js
@@ -25,6 +25,26 @@ test('express total response', () => {
   })
 })
 
+test('custom timing name and description', () => {
+  const app = express()
+  app.use(serverTiming({
+    name: 'app',
+    description: 'Service Layer Response Time'
+  }))
+  app.use((req, res, next) => {
+    res.send('hello')
+  })
+  const server = app.listen(0, () => {
+    http.get(`http://localhost:${server.address().port}/`, mustCall((res) => {
+      const assertStream = new AssertStream()
+      assertStream.expect('hello')
+      res.pipe(assertStream)
+      assert(/app; dur=.*; desc="Service Layer Response Time"/.test(res.headers['server-timing']))
+      server.close()
+    }))
+  })
+})
+
 test('express add some custom server timing header', () => {
   const app = express()
   app.use(serverTiming())


### PR DESCRIPTION
Our application is an internal layer. We want to add other server timing items to the header.
I was hoping I could customise the name of this layer to better reflect it's location in the system.
(Load Balancer: total, Express app: application).