### PR TITLE
Use multiple headers instead of joined string

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = function serverTiming (options) {
       if (enabled) {
         const existingHeaders = res.getHeader('Server-Timing')
 
-        res.setHeader('Server-Timing', [].concat(existingHeaders || []).concat(headers).join(', '))
+        res.setHeader('Server-Timing', [].concat(existingHeaders || []).concat(headers))
       }
     })
     if (typeof next === 'function') {


### PR DESCRIPTION
This micro-optimisation fits better with the industry standards for multiple entries on the same header.

Multiple headers work just as well:

| Before
| -
| ![](https://user-images.githubusercontent.com/516342/138751766-30872d6a-a85f-428e-8f43-5c872ff9cd0c.png)

| After
| -
| ![](https://user-images.githubusercontent.com/516342/138751140-55a1ae37-6029-4fb8-8eca-9626cacdbefc.png)
