### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/yosuke-furukawa/server-timing.git"
+    "url": "git+https://github.com/yosuke-furukawa/server-timing.git"
   },
   "keywords": [
     "server-timing",


### PR DESCRIPTION
Summary
- Change package.json repository metadata from the SSH form to the public HTTPS Git URL.
- Keep package source and runtime behavior unchanged.

Validation
- Parsed package.json and confirmed repository.url is git+https://github.com/yosuke-furukawa/server-timing.git.
- Ran git diff --check.
- Verified the HTTPS Git remote resolves with git ls-remote https://github.com/yosuke-furukawa/server-timing.git HEAD.